### PR TITLE
Add loading icons and regex

### DIFF
--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 
 from flask import abort
 from flask import session as flask_session
@@ -121,7 +122,7 @@ def commit_schedule(table, all_locations):
                     location = table[i][j].upper()
                 elif table[i][j] == '-' or table[i][j] == 'DROP':
                     continue
-                elif ':' in table[i][j]:
+                elif re.search("^[\d]:[\d][\d]$", table[i][j]) or re.search("^[\d][\d]:[\d][\d]$", table[i][j]):
                     split_time = table[i][j].split(':')
                     if int(split_time[0]) == 12 or 1 <= int(split_time[0]) < 6:
                         joined_time = '.'.join(split_time)

--- a/shuttle/schedules/__init__.py
+++ b/shuttle/schedules/__init__.py
@@ -1,4 +1,5 @@
-import datetime
+import re
+from datetime import datetime
 from flask import render_template, request, session
 from flask_classy import FlaskView, route
 from shuttle.db import db_functions as db
@@ -82,7 +83,7 @@ class SchedulesView(FlaskView):
     def shuttle_logs(self):
         json_data = request.get_json()
         if json_data == "today's date":
-            now = datetime.datetime.now()
+            now = datetime.now()
             date = now.strftime('%b-%d-%Y')
         else:
             date = json_data['date']
@@ -182,7 +183,8 @@ class SchedulesView(FlaskView):
             for i in range(len(schedule)):
                 for j in range(len(schedule[i])):
                     # All times are converted to the same format so they can be compared
-                    if j != 0 and ':' in schedule[i][j]:
+                    if j != 0 and re.search("^[\d]:[\d][\d]$", schedule[i][j]) or re.search("^[\d][\d]:[\d][\d]$",
+                                                                                            schedule[i][j]):
                         split_time = schedule[i][j].split(':')
                         if int(split_time[0]) == 12 or 1 <= int(split_time[0]) < 6:
                             schedule_time = (schedule[i][j] + ' PM')

--- a/shuttle/static/assets/css/shuttle.css
+++ b/shuttle/static/assets/css/shuttle.css
@@ -105,6 +105,14 @@ span.shuttle-title {
     color: #ffc600;
 }
 
+.spinner-img {
+    height: auto;
+    width: 2em;
+    position: fixed;
+    padding-top: 0.5em;
+    animation: ease-in-out;
+}
+
 .submit {
     margin: 0.3em;
 }

--- a/shuttle/templates/schedules/driver_logs.html
+++ b/shuttle/templates/schedules/driver_logs.html
@@ -6,6 +6,7 @@
         <div class="align-side-by-side">
             <div class="dropdown">
                 <button class="btn btn-primary btn-lg dropdown-toggle date-menu" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Select a date</button>
+                <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading" style="display:none"/>
                 <div class="dropdown-menu scrollable-menu" aria-labelledby="dropdownMenuButton">
                     {% for i in range(date_list|length) %}
                         <a class="dropdown-item" href="#">{{ date_list[i] }}</a>
@@ -21,12 +22,14 @@
         $(document).ready(function() {
             window.onload = load_data("today's date");
             function load_data(data){
+                $('#img-spinner').show();
                 $.ajax({
                     type: 'POST',
                     contentType: 'application/json',
                     url: "{{ url_for('SchedulesView:shuttle_logs') }}",
                     data: JSON.stringify((data)),
                 }).done(function (data) {
+                    $('#img-spinner').hide();
                     $("#driver_log_display").html(data);
                 });
             }
@@ -35,7 +38,7 @@
                 $(".date-menu:first-child").text($(this).text());
                 $(".date-menu:first-child").val($(this).text());
                 // Sends data to be shown on screen
-                 var data = {"date": $('.date-menu').val()}
+                var data = {"date": $('.date-menu').val()}
                 load_data(data);
             });
          });

--- a/shuttle/templates/schedules/edit_shuttle_schedule.html
+++ b/shuttle/templates/schedules/edit_shuttle_schedule.html
@@ -13,16 +13,19 @@
         <iframe width="100%" height=265 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTy3uE_5hm1xmXyHdlAUwh3UF31yNw_lE1fACWoj1f3ND-UsMsveEe_FDHLLc8pHxgd4YwmdGBqMWRU/pubhtml?widget=true&amp;headers=false"></iframe>
     </div>
     <div class="center-page">
-         <input id="submit-schedule-button" class="btn btn-warning btn-sm" type="submit" value="Submit to Database">
+        <input id="submit-schedule-button" class="btn btn-warning btn-sm" type="submit" value="Submit to Database">
+        <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading" style="display:none; padding-top:0em"/>
     </div>
 
     <script>
         $(document).ready(function() {
             $("#submit-schedule-button").click(function () {
+                $('.spinner-img').show();
                 // Sends google sheets schedule to database (erases old schedule)
                 $.ajax({
                     url: "{{ url_for('SchedulesView:send_schedule_path') }}",
                 }).done(function(data) {
+                    $('img-spinner').hide();
                     location.reload()
                 })
             });

--- a/shuttle/templates/schedules/shuttle_driver_check_in.html
+++ b/shuttle/templates/schedules/shuttle_driver_check_in.html
@@ -6,6 +6,7 @@
     <div class="driver-selector">
         <div class="dropdown">
             <button class="btn btn-primary btn-lg dropdown-toggle driver-view-menu" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Driver View</button>
+            <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading"/>
             <div class="dropdown-menu " aria-labelledby="dropdownMenuButton">
                 <a class="dropdown-item" href="#">Location Check In</a>
                 <a class="dropdown-item" href="#">Active Requests</a>
@@ -26,10 +27,12 @@
                     url: "{{ url_for('SchedulesView:load_driver_view') }}",
                     data: JSON.stringify((data)),
                 }).done(function (data) {
+                    $('.spinner-img').hide()
                     $("#driver_check_in_display").html(data);
                 });
             }
             $(".dropdown-menu a").click(function() {
+                $('.spinner-img').show()
                 // Dropdown shows location selected
                 $(".driver-view-menu:first-child").text($(this).text());
                 $(".driver-view-menu:first-child").val($(this).text());

--- a/shuttle/views.py
+++ b/shuttle/views.py
@@ -11,8 +11,8 @@ class View(FlaskView):
         self.sv = SchedulesView()
 
     def index(self):
-        route_data = self.sv.grab_current_route()
         check_in_data = self.sv.grab_check_in_driver_data()
+        route_data = self.sv.grab_current_route()
         return render_template('index.html', **locals())
 
     @route('/clear')


### PR DESCRIPTION
## Description
Adds loading icons to buttons that don't have page loading icons (more loading icons could be added to other buttons but every other button either loads super fast or the page has a loading icon letting the user know the page is loading info)
Use regex to more accurately check dates. 
Other small fixes

Fixes # (N/A)

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix
- New feature


## How Has This Been Tested?

Functions using regex work correctly and buttons with loading icons show when clicked and disappear when finished

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
