### PR TITLE
Edit schedule fix

### DIFF
--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -356,7 +356,7 @@ def get_last_location():
     return recent_data
 
 
-def grab_db_schedule():
+def get_db_schedule():
     sql = "SELECT LOCATION, ARRIVAL_TIME FROM SHUTTLE_SCHEDULE ORDER BY ID"
     results = query(sql, 'read')
     return results

--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -346,10 +346,10 @@ def get_last_location():
           "(SELECT * FROM SHUTTLE_DRIVER_LOGS WHERE LOCATION IS NOT NULL ORDER BY ID DESC) Where ROWNUM = 1"
     results = query(sql, 'read')
     if results[0]['arrival_time']:
-        time = results[0]['arrival_time'].strftime('%I:%M %p')
+        time = results[0]['arrival_time'].strftime('%#I:%M %p')
         recent_data = {"location": results[0]['location'], "time": time}
     elif results[0]['departure_time']:
-        time = results[0]['departure_time'].strftime('%I:%M %p')
+        time = results[0]['departure_time'].strftime('%#I:%M %p')
         recent_data = {"location": results[0]['location'], "time": time}
     else:
         return "Error"

--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -316,7 +316,7 @@ def get_requests():
     for result in results:
         real_name = username_search(results[result]['username'])
         results[result]['name'] = real_name[0]['firstName'] + ' ' + real_name[0]['lastName']
-        results[result]['log_date'] = results[result]['log_date'].strftime('%I:%M %p %b-%d-%Y')
+        results[result]['log_date'] = results[result]['log_date'].strftime('%#I:%M %p %b-%d-%Y')
     return results
 
 

--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -110,8 +110,6 @@ def username_search(username):
       
 def commit_schedule(table, all_locations):
     try:
-        sql = "DELETE FROM SHUTTLE_SCHEDULE"
-        query(sql, 'write')
         all_locations = [i.upper() for i in all_locations]
         queries = []
         for i in range(len(table)):
@@ -137,6 +135,8 @@ def commit_schedule(table, all_locations):
                         (location, arrival_time)
                     queries.append(sql)
         # Don't commit until finished in case it fails (memory inefficient but needed)
+        sql = "DELETE FROM SHUTTLE_SCHEDULE"
+        query(sql, 'write')
         for sql in queries:
             query(sql, 'write')
         return 'success'

--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -316,7 +316,8 @@ def get_requests():
     for result in results:
         real_name = username_search(results[result]['username'])
         results[result]['name'] = real_name[0]['firstName'] + ' ' + real_name[0]['lastName']
-        results[result]['log_date'] = results[result]['log_date'].strftime('%#I:%M %p %b-%d-%Y')
+        results[result]['log_date'] = results[result]['log_date'].strftime('%I:%M %p %b-%d-%Y')\
+            .lstrip("0").replace(" 0", " ")
     return results
 
 
@@ -346,10 +347,10 @@ def get_last_location():
           "(SELECT * FROM SHUTTLE_DRIVER_LOGS WHERE LOCATION IS NOT NULL ORDER BY ID DESC) Where ROWNUM = 1"
     results = query(sql, 'read')
     if results[0]['arrival_time']:
-        time = results[0]['arrival_time'].strftime('%#I:%M %p')
+        time = results[0]['arrival_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
         recent_data = {"location": results[0]['location'], "time": time}
     elif results[0]['departure_time']:
-        time = results[0]['departure_time'].strftime('%#I:%M %p')
+        time = results[0]['departure_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
         recent_data = {"location": results[0]['location'], "time": time}
     else:
         return "Error"

--- a/shuttle/schedules/__init__.py
+++ b/shuttle/schedules/__init__.py
@@ -247,8 +247,10 @@ class SchedulesView(FlaskView):
                             else:
                                 if schedule_time < closest_time_greater:
                                     closest_time_greater = schedule_time
-                                    next_stop = {'location': schedule[i][0],
-                                                 'time': closest_time_greater.strftime('%#I:%M %p')}
+                                    next_stop = {
+                                        'location': schedule[i][0],
+                                        'time': closest_time_greater.strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
+                                    }
             return next_stop
         except:
             return {'location': 'Error', 'time': 'Error'}

--- a/shuttle/schedules/__init__.py
+++ b/shuttle/schedules/__init__.py
@@ -18,7 +18,7 @@ class SchedulesView(FlaskView):
 
     @route('/shuttle-schedule')
     def schedule(self):
-        schedule = self.shc.grab_schedule()
+        schedule = self.ssc.grab_db_schedule()
         return render_template('schedules/shuttle_schedule.html', **locals())
 
     @route('/request-shuttle')
@@ -33,7 +33,8 @@ class SchedulesView(FlaskView):
     @route('/edit-schedule')
     def edit_schedule(self):
         self.sc.check_roles_and_route(['Administrator'])
-        return render_template('schedules/edit_shuttle_schedule.html')
+        schedule = self.shc.grab_schedule()
+        return render_template('schedules/edit_shuttle_schedule.html', **locals())
 
     @route('/driver-check-in')
     def check_in(self):
@@ -83,49 +84,6 @@ class SchedulesView(FlaskView):
         date_list = grabbed_logs[1]
         return render_template('schedules/driver_logs.html', **locals())
 
-    @route('/users')
-    def users(self):
-        self.sc.check_roles_and_route(['Administrator'])
-        shuttle_user = db.get_users()
-
-        current_user = session['USERNAME']
-
-        for key in shuttle_user:
-            shuttle_user[key]['name'] = db.username_search(shuttle_user[key]['username'])[0]['firstName'] + \
-                                        ' ' + db.username_search(shuttle_user[key]['username'])[0]['lastName']
-
-        return render_template('/schedules/users.html', **locals())
-
-    @route('load_user_data', methods=['POST', 'GET'])
-    def load_user_data(self):
-        self.sc.check_roles_and_route(['Administrator'])
-        username = json.loads(request.data).get('username')
-        return render_template('/schedules/user_modal.html', **locals())
-
-    @route('delete_user', methods=['POST'])
-    def delete_user(self):
-        self.sc.check_roles_and_route(['Administrator'])
-        username = json.loads(request.data).get('username')
-        if username != session['USERNAME']:
-            result = db.delete_user(username)
-            return result
-        else:
-            self.sc.set_alert('danger', 'You cannot delete your own account.')
-            return 'error'
-
-
-    @route('edit_user', methods=['POST'])
-    def edit_user(self):
-        self.sc.check_roles_and_route(['Administrator'])
-        username = json.loads(request.data).get('username')
-        role = json.loads(request.data).get('role')
-        if username != session['USERNAME']:
-            result = db.change_user_role(username, role)
-            return result
-        else:
-            self.sc.set_alert('danger', 'You cannot edit your own account.')
-            return 'error'
-
     @route('/shuttle-logs', methods=['GET', 'POST'])
     def shuttle_logs(self):
         json_data = request.get_json()
@@ -138,6 +96,48 @@ class SchedulesView(FlaskView):
         shuttle_logs = selected_logs[0]
         break_logs = selected_logs[1]
         return render_template('loaded_views/load_logs.html', **locals())
+
+    @route('/users')
+    def users(self):
+        self.sc.check_roles_and_route(['Administrator'])
+        shuttle_user = db.get_users()
+
+        current_user = session['USERNAME']
+
+        for key in shuttle_user:
+            shuttle_user[key]['name'] = db.username_search(shuttle_user[key]['username'])[0]['firstName'] + \
+                                        ' ' + db.username_search(shuttle_user[key]['username'])[0]['lastName']
+
+        return render_template('schedules/users.html', **locals())
+
+    @route('load_user_data', methods=['POST', 'GET'])
+    def load_user_data(self):
+        self.sc.check_roles_and_route(['Administrator'])
+        username = json.loads(request.data).get('username')
+        return render_template('schedules/user_modal.html', **locals())
+
+    @route('delete_user', methods=['POST'])
+    def delete_user(self):
+        self.sc.check_roles_and_route(['Administrator'])
+        username = json.loads(request.data).get('username')
+        if username != session['USERNAME']:
+            result = db.delete_user(username)
+            return result
+        else:
+            self.sc.set_alert('danger', 'You cannot delete your own account.')
+            return 'error'
+
+    @route('edit_user', methods=['POST'])
+    def edit_user(self):
+        self.sc.check_roles_and_route(['Administrator'])
+        username = json.loads(request.data).get('username')
+        role = json.loads(request.data).get('role')
+        if username != session['USERNAME']:
+            result = db.change_user_role(username, role)
+            return result
+        else:
+            self.sc.set_alert('danger', 'You cannot edit your own account.')
+            return 'error'
 
     def send_schedule_path(self):
         self.sc.check_roles_and_route(['Administrator'])

--- a/shuttle/schedules/__init__.py
+++ b/shuttle/schedules/__init__.py
@@ -18,6 +18,7 @@ class SchedulesView(FlaskView):
 
     @route('/shuttle-schedule')
     def schedule(self):
+        # Shows schedule from database
         schedule = self.ssc.grab_db_schedule()
         return render_template('schedules/shuttle_schedule.html', **locals())
 
@@ -33,6 +34,7 @@ class SchedulesView(FlaskView):
     @route('/edit-schedule')
     def edit_schedule(self):
         self.sc.check_roles_and_route(['Administrator'])
+        # Show schedule directly from sheets
         schedule = self.shc.grab_schedule()
         return render_template('schedules/edit_shuttle_schedule.html', **locals())
 

--- a/shuttle/schedules/__init__.py
+++ b/shuttle/schedules/__init__.py
@@ -248,7 +248,7 @@ class SchedulesView(FlaskView):
                                 if schedule_time < closest_time_greater:
                                     closest_time_greater = schedule_time
                                     next_stop = {'location': schedule[i][0],
-                                                 'time': closest_time_greater.strftime('%I:%M %p')}
+                                                 'time': closest_time_greater.strftime('%#I:%M %p')}
             return next_stop
         except:
             return {'location': 'Error', 'time': 'Error'}

--- a/shuttle/schedules/shuttle_schedules_controller.py
+++ b/shuttle/schedules/shuttle_schedules_controller.py
@@ -43,3 +43,22 @@ class ScheduleController(object):
                 break_logs[break_iter] = all_shuttle_logs[i]
                 break_iter += 1
         return shuttle_logs, break_logs
+
+    def grab_db_schedule(self):
+        schedule = db.grab_db_schedule()
+        location = ''
+        schedule_list = []
+        location_list = []
+        for i in range(len(schedule)):
+            if schedule[i]['location'] != location:
+                location_list = []
+                schedule_list.append(location_list)
+                location = schedule[i]['location']
+                location_list.append(location)
+            if schedule[i]['arrival_time'].strftime('%d-%b-%Y %I:%M %p') == '01-Aug-2000 01:00 PM':
+                location_list.append('-')
+            else:
+                time = schedule[i]['arrival_time'].strftime('%I:%M')
+                location_list.append(time)
+
+        return schedule_list

--- a/shuttle/schedules/shuttle_schedules_controller.py
+++ b/shuttle/schedules/shuttle_schedules_controller.py
@@ -58,7 +58,7 @@ class ScheduleController(object):
             if schedule[i]['arrival_time'].strftime('%d-%b-%Y %I:%M %p') == '01-Aug-2000 01:00 PM':
                 location_list.append('-')
             else:
-                time = schedule[i]['arrival_time'].strftime('%#I:%M')
+                time = schedule[i]['arrival_time'].strftime('%-I:%M')
                 location_list.append(time)
 
         return schedule_list

--- a/shuttle/schedules/shuttle_schedules_controller.py
+++ b/shuttle/schedules/shuttle_schedules_controller.py
@@ -33,9 +33,11 @@ class ScheduleController(object):
             all_shuttle_logs[i]['name'] = real_name[0]['firstName'] + ' ' + real_name[0]['lastName']
             all_shuttle_logs[i]['log_date'] = all_shuttle_logs[i]['log_date'].strftime('%b-%d-%Y')
             if all_shuttle_logs[i]['arrival_time']:
-                all_shuttle_logs[i]['arrival_time'] = all_shuttle_logs[i]['arrival_time'].strftime('%#I:%M %p %b-%d-%Y')
+                all_shuttle_logs[i]['arrival_time'] = all_shuttle_logs[i]['arrival_time'].strftime('%I:%M %p %b-%d-%Y')\
+                    .lstrip("0").replace(" 0", " ")
             elif all_shuttle_logs[i]['departure_time']:
-                all_shuttle_logs[i]['departure_time'] = all_shuttle_logs[i]['departure_time'].strftime('%#I:%M %p %b-%d-%Y')
+                all_shuttle_logs[i]['departure_time'] = all_shuttle_logs[i]['departure_time'].strftime('%I:%M %p %b-%d-%Y')\
+                    .lstrip("0").replace(" 0", " ")
             if all_shuttle_logs[i]['location']:
                 shuttle_logs[shuttle_iter] = all_shuttle_logs[i]
                 shuttle_iter += 1
@@ -58,7 +60,7 @@ class ScheduleController(object):
             if schedule[i]['arrival_time'].strftime('%d-%b-%Y %I:%M %p') == '01-Aug-2000 01:00 PM':
                 location_list.append('-')
             else:
-                time = schedule[i]['arrival_time'].strftime('%-I:%M')
+                time = schedule[i]['arrival_time'].strftime('%I:%M').lstrip("0").replace(" 0", " ")
                 location_list.append(time)
 
         return schedule_list

--- a/shuttle/schedules/shuttle_schedules_controller.py
+++ b/shuttle/schedules/shuttle_schedules_controller.py
@@ -45,7 +45,7 @@ class ScheduleController(object):
         return shuttle_logs, break_logs
 
     def grab_db_schedule(self):
-        schedule = db.grab_db_schedule()
+        schedule = db.get_db_schedule()
         location = ''
         schedule_list = []
         location_list = []

--- a/shuttle/schedules/shuttle_schedules_controller.py
+++ b/shuttle/schedules/shuttle_schedules_controller.py
@@ -33,9 +33,9 @@ class ScheduleController(object):
             all_shuttle_logs[i]['name'] = real_name[0]['firstName'] + ' ' + real_name[0]['lastName']
             all_shuttle_logs[i]['log_date'] = all_shuttle_logs[i]['log_date'].strftime('%b-%d-%Y')
             if all_shuttle_logs[i]['arrival_time']:
-                all_shuttle_logs[i]['arrival_time'] = all_shuttle_logs[i]['arrival_time'].strftime('%I:%M %p %b-%d-%Y')
+                all_shuttle_logs[i]['arrival_time'] = all_shuttle_logs[i]['arrival_time'].strftime('%#I:%M %p %b-%d-%Y')
             elif all_shuttle_logs[i]['departure_time']:
-                all_shuttle_logs[i]['departure_time'] = all_shuttle_logs[i]['departure_time'].strftime('%I:%M %p %b-%d-%Y')
+                all_shuttle_logs[i]['departure_time'] = all_shuttle_logs[i]['departure_time'].strftime('%#I:%M %p %b-%d-%Y')
             if all_shuttle_logs[i]['location']:
                 shuttle_logs[shuttle_iter] = all_shuttle_logs[i]
                 shuttle_iter += 1
@@ -58,7 +58,7 @@ class ScheduleController(object):
             if schedule[i]['arrival_time'].strftime('%d-%b-%Y %I:%M %p') == '01-Aug-2000 01:00 PM':
                 location_list.append('-')
             else:
-                time = schedule[i]['arrival_time'].strftime('%I:%M')
+                time = schedule[i]['arrival_time'].strftime('%#I:%M')
                 location_list.append(time)
 
         return schedule_list

--- a/shuttle/static/assets/css/shuttle.css
+++ b/shuttle/static/assets/css/shuttle.css
@@ -62,6 +62,10 @@ div.footer {
     margin-bottom: 1em;
 }
 
+.even-row {
+    background: hsla(240, 100%, 85%, 0.25);
+}
+
 html, body {
     background-color: #fafafa;
 }

--- a/shuttle/templates/loaded_views/load_schedule.html
+++ b/shuttle/templates/loaded_views/load_schedule.html
@@ -3,14 +3,22 @@
     <div class="column">
         <div class="card">
             <div class="card-body log-body">
-                <table class="table table-hover">
+                <table class="table">
                     <tbody>
                         {% for i in range(schedule|length) %}
-                            <tr>
-                                <td>
-                                    <h6 class="schedule-location">{{ schedule[i][0] }}</h6>
-                                </td>
-                            </tr>
+                            {% if i % 2 == 0 %}
+                                <tr class="even-row">
+                                    <td>
+                                        <h6 class="schedule-location">{{ schedule[i][0] }}</h6>
+                                    </td>
+                                </tr>
+                            {% else %}
+                                <tr class="even-odd">
+                                    <td>
+                                        <h6 class="schedule-location">{{ schedule[i][0] }}</h6>
+                                    </td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -23,15 +31,27 @@
             <table class="table table-hover">
                 <tbody>
                 {% for i in range(schedule|length) %}
-                    <tr>
-                        {% for j in range(schedule[i]|length) %}
-                            <td>
-                                {% if j != 0 %}
-                                    <h6 class="schedule-time">{{ schedule[i][j] }}</h6>
-                                {% endif %}
-                            </td>
-                        {% endfor %}
-                    </tr>
+                    {% if i % 2 == 0 %}
+                        <tr class="even-row">
+                            {% for j in range(schedule[i]|length) %}
+                                <td>
+                                    {% if j != 0 %}
+                                        <h6 class="schedule-time">{{ schedule[i][j] }}</h6>
+                                    {% endif %}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    {% else %}
+                        <tr class="odd-row">
+                            {% for j in range(schedule[i]|length) %}
+                                <td>
+                                    {% if j != 0 %}
+                                        <h6 class="schedule-time">{{ schedule[i][j] }}</h6>
+                                    {% endif %}
+                                </td>
+                            {% endfor %}
+                        </tr>
+                    {% endif %}
                 {% endfor %}
                 </tbody>
             </table>

--- a/shuttle/templates/loaded_views/load_schedule.html
+++ b/shuttle/templates/loaded_views/load_schedule.html
@@ -1,0 +1,41 @@
+{% block body_content %}
+
+    <div class="column">
+        <div class="card">
+            <div class="card-body log-body">
+                <table class="table table-hover">
+                    <tbody>
+                        {% for i in range(schedule|length) %}
+                            <tr>
+                                <td>
+                                    <h6 class="schedule-location">{{ schedule[i][0] }}</h6>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card scrolling-wrapper">
+        <div class="card-body log-body">
+            <table class="table table-hover">
+                <tbody>
+                {% for i in range(schedule|length) %}
+                    <tr>
+                        {% for j in range(schedule[i]|length) %}
+                            <td>
+                                {% if j != 0 %}
+                                    <h6 class="schedule-time">{{ schedule[i][j] }}</h6>
+                                {% endif %}
+                            </td>
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+{% endblock %}

--- a/shuttle/templates/schedules/edit_shuttle_schedule.html
+++ b/shuttle/templates/schedules/edit_shuttle_schedule.html
@@ -7,6 +7,7 @@
     </div>
     <div class="center-page">
         <h6>Use <a href="https://docs.google.com/spreadsheets/d/1VGuZm58MfKW7TBFG09oGT8eIEAH1A4iFUg1utj1AA4s/edit?usp=sharing">this link </a>to change the schedule</h6>
+        <h6>Please enter locations into the first column. Times should be in the format (00:00 / 0:00) or (-) if the location has no time in a column</h6>
     </div>
     <div class="center-page">
         {% include 'loaded_views/load_schedule.html' %}

--- a/shuttle/templates/schedules/edit_shuttle_schedule.html
+++ b/shuttle/templates/schedules/edit_shuttle_schedule.html
@@ -9,9 +9,9 @@
         <h6>Use <a href="https://docs.google.com/spreadsheets/d/1VGuZm58MfKW7TBFG09oGT8eIEAH1A4iFUg1utj1AA4s/edit?usp=sharing">this link </a>to change the schedule</h6>
     </div>
     <div class="center-page">
-        <iframe width="100%" height=265 src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTy3uE_5hm1xmXyHdlAUwh3UF31yNw_lE1fACWoj1f3ND-UsMsveEe_FDHLLc8pHxgd4YwmdGBqMWRU/pubhtml?widget=true&amp;headers=false"></iframe>
+        {% include 'loaded_views/load_schedule.html' %}
     </div>
-    <div class="center-page">
+    <div class="center-page" style="padding-top:1em">
         <input id="submit-schedule-button" class="btn btn-warning btn-sm" type="submit" value="Submit to Database">
         <img id="img-spinner" class="spinner-img" src="https://cdn1.bethel.edu/images/load.gif" alt="Loading" style="display:none; padding-top:0em"/>
     </div>

--- a/shuttle/templates/schedules/shuttle_schedule.html
+++ b/shuttle/templates/schedules/shuttle_schedule.html
@@ -8,42 +8,6 @@
         <h4 class="card-title">Shuttle Schedule</h4>
     </div>
 
-    <div class="column">
-        <div class="card">
-            <div class="card-body log-body">
-                <table class="table table-hover">
-                    <tbody>
-                        {% for i in range(schedule|length) %}
-                            <tr>
-                                <td>
-                                    <h6 class="schedule-location">{{ schedule[i][0] }}</h6>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
-    </div>
-
-    <div class="card scrolling-wrapper">
-        <div class="card-body log-body">
-            <table class="table table-hover">
-                <tbody>
-                {% for i in range(schedule|length) %}
-                    <tr>
-                        {% for j in range(schedule[i]|length) %}
-                            <td>
-                                {% if j != 0 %}
-                                    <h6 class="schedule-time">{{ schedule[i][j] }}</h6>
-                                {% endif %}
-                            </td>
-                        {% endfor %}
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
+    {% include 'loaded_views/load_schedule.html' %}
 
 {% endblock %}

--- a/shuttle/templates/schedules/shuttle_schedule.html
+++ b/shuttle/templates/schedules/shuttle_schedule.html
@@ -7,7 +7,8 @@
     <div class="center-page">
         <h4 class="card-title">Shuttle Schedule</h4>
     </div>
-
-    {% include 'loaded_views/load_schedule.html' %}
+    <div class="center-page">
+        {% include 'loaded_views/load_schedule.html' %}
+    </div>
 
 {% endblock %}


### PR DESCRIPTION
## Description

Schedules are now loaded in separate html file that can be put on any page if included. Edit Schedule takes directly from the Google Sheets but Shuttle Schedule takes from the database now. Even rows of schedule are now colored with a faint grey.

Fixes # N/A

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Both schedules look correct. Shuttle Schedule shows what is in the database and Edit Schedule shows what is in the spreadsheet. Having an error in the Google Sheet throws an error but the data isn't submitted to database so Shuttle Schedule doesn't change.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
