### PR TITLE
Fix minutes for reload in driver check in

### DIFF
--- a/shuttle/templates/driver_check_in/load_driver_check_locations.html
+++ b/shuttle/templates/driver_check_in/load_driver_check_locations.html
@@ -75,7 +75,7 @@
         setInterval(check_time, 30000);
         function check_time() {
             var today = new Date();
-            var time = (today.getHours() % 12) + ":" + today.getMinutes();
+            var time = (today.getHours() % 12) + ":" + ('0' + today.getMinutes()).slice(-2);
             if (time >= {{ next_time.split(' ')[0]|tojson }}) {
                 location.reload();
             }


### PR DESCRIPTION
## Description

Fixes minutes for the driver check in reload. The minutes from 0-9 printed withoout a zero. So 9:09 was 9:9 instead of 9:09 as an example.

Fixes #N/A 

## Size and Type of change

- Bug fix

## How Has This Been Tested?

I printed the times every time it reloaded the page and the times were correct

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
