### PR TITLE
Only displays check ins if there have been some that day

### DIFF
--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -347,11 +347,13 @@ def get_last_location():
           "(SELECT * FROM SHUTTLE_DRIVER_LOGS WHERE LOCATION IS NOT NULL ORDER BY ID DESC) Where ROWNUM = 1"
     results = query(sql, 'read')
     if results[0]['arrival_time']:
-        time = results[0]['arrival_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
-        recent_data = {"location": results[0]['location'], "time": time}
+        last_time = results[0]['arrival_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
+        last_date = results[0]['arrival_time'].strftime('%b-%d-%y')
+        recent_data = {'location': results[0]['location'], 'time': last_time, 'date': last_date}
     elif results[0]['departure_time']:
-        time = results[0]['departure_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
-        recent_data = {"location": results[0]['location'], "time": time}
+        last_time = results[0]['departure_time'].strftime('%I:%M %p').lstrip("0").replace(" 0", " ")
+        last_date = results[0]['departure_time'].strftime('%b-%d-%y')
+        recent_data = {'location': results[0]['location'], 'time': last_time, 'date': last_date}
     else:
         return "Error"
     return recent_data

--- a/shuttle/homepage/homepage_controller.py
+++ b/shuttle/homepage/homepage_controller.py
@@ -12,6 +12,11 @@ class HomePageController:
 
     def grab_check_in_driver_data(self):
         data = db.get_last_location()
+        now = datetime.now()
+        current_date = now.strftime('%b-%d-%y')
+        if data['date'] != current_date:
+            data['location'] = 'No check ins for today'
+            data['time'] = 'N/A'
         return data
 
     # Method takes the last time checked in by the driver and uses that to find the next closest


### PR DESCRIPTION
## Description

If there haven't been any check ins in the morning, the homepage displays a message saying so rather than showing a check in from the previous day

Fixes #46 

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

There was previously a check in from the day before on the site. After making changes to the code, it showed "no check ins yet today". I then checked in for a driver and that check in showed up

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code