### PR TITLE
Request shuttle update options

### DIFF
--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -376,6 +376,9 @@ def get_requests():
         results[result]['name'] = real_name[0]['firstName'] + ' ' + real_name[0]['lastName']
         results[result]['log_date'] = results[result]['log_date'].strftime('%I:%M %p %b-%d-%Y') \
             .lstrip("0").replace(" 0", " ")
+        number = check_for_number(results[result]['username'])
+        if number:
+            results[result]['phone_number'] = number[0]['phone_number']
     return results
 
 
@@ -466,8 +469,7 @@ def get_campus_locations():
     return results
 
 
-def check_for_number():
-    username = flask_session['USERNAME']
+def check_for_number(username):
     sql = "Select PHONE_NUMBER FROM SHUTTLE_PHONE_LOOKUP WHERE USERNAME = '{0}'".format(username)
     results = query(sql, 'read')
     return results
@@ -477,6 +479,16 @@ def send_phone_number(phone_number):
     try:
         username = flask_session['USERNAME']
         sql = "INSERT INTO SHUTTLE_PHONE_LOOKUP(USERNAME, PHONE_NUMBER) VALUES ('{0}','{1}')".format(username, phone_number)
+        query(sql, 'write')
+        return 'success'
+    except:
+        return 'Error'
+
+
+def delete_number():
+    try:
+        username = flask_session['USERNAME']
+        sql = "DELETE FROM SHUTTLE_PHONE_LOOKUP WHERE USERNAME = '{0}'".format(username)
         query(sql, 'write')
         return 'success'
     except:

--- a/shuttle/db/db_functions.py
+++ b/shuttle/db/db_functions.py
@@ -464,3 +464,20 @@ def get_campus_locations():
     sql = "Select LOCATION from SHUTTLE_CAMPUS_LOCATIONS ORDER BY ID"
     results = query(sql, 'read')
     return results
+
+
+def check_for_number():
+    username = flask_session['USERNAME']
+    sql = "Select PHONE_NUMBER FROM SHUTTLE_PHONE_LOOKUP WHERE USERNAME = '{0}'".format(username)
+    results = query(sql, 'read')
+    return results
+
+
+def send_phone_number(phone_number):
+    try:
+        username = flask_session['USERNAME']
+        sql = "INSERT INTO SHUTTLE_PHONE_LOOKUP(USERNAME, PHONE_NUMBER) VALUES ('{0}','{1}')".format(username, phone_number)
+        query(sql, 'write')
+        return 'success'
+    except:
+        return 'Error'

--- a/shuttle/templates/driver_check_in/load_driver_check_requests.html
+++ b/shuttle/templates/driver_check_in/load_driver_check_requests.html
@@ -14,6 +14,7 @@
                             <thead>
                             <tr>
                                 <th scope="col">Name</th>
+                                <th scope="col">Phone Number</th>
                                 <th scope="col">Time Of Request</th>
                                 <th scope="col">Pick Up At</th>
                                 <th scope="col">Drop Off At</th>
@@ -29,17 +30,22 @@
                                             {{ requests[request]['name'] }}
                                         {% endif %}
                                     </td>
-                                    <td class="location">
+                                    <td class="number">
+                                        {% if requests[request]['phone_number'] != None %}
+                                            {{ requests[request]['phone_number'] }}
+                                        {% endif %}
+                                    </td>
+                                    <td class="request-time">
                                         {% if requests[request]['log_date'] != None %}
                                             {{ requests[request]['log_date'] }}
                                         {% endif %}
                                     </td>
-                                    <td class="check-out">
+                                    <td class="pick-up">
                                         {% if requests[request]['pick_up_location'] != None %}
                                             {{ requests[request]['pick_up_location'] }}
                                         {% endif %}
                                     </td>
-                                    <td class="check-in">
+                                    <td class="drop-off">
                                         {% if requests[request]['drop_off_location'] != None %}
                                             {{ requests[request]['drop_off_location'] }}
                                         {% endif %}

--- a/shuttle/templates/request_shuttle/request_shuttle.html
+++ b/shuttle/templates/request_shuttle/request_shuttle.html
@@ -64,14 +64,23 @@
                     </div>
                 </div>
             </div>
-            <form>
+            {% if phone_number %}
                 <div class="align-side-by-side">
-                    <h4>Phone number (Optional):</h4>
+                    <p>Phone number On Record: <b>{{ phone_number }}</b></p>
                 </div>
-                <div class="align-side-by-side">
-                    <input type="tel" id="phone" name="phone" placeholder="___-___-____" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
-                </div>
-            </form>
+            {% else %}
+                <form>
+                    <div class="align-side-by-side">
+                        <h4>Phone number:</h4>
+                    </div>
+                    <div class="align-side-by-side">
+                        <input class="phone-number" type="tel" id="phone" name="phone" placeholder="ex. 123-123-1234" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
+                    </div>
+                    <div class="align-side-by-side">
+                        <h6>(Optional)</h6>
+                    </div>
+                </form>
+            {% endif %}
             <div class="center-page">
                 <div class="align-side-by-side">
                     <div class="submit">
@@ -141,7 +150,8 @@
                 }
                 var data = {
                     "pick-up-location":pick_up,
-                    "drop-off-location":drop_off
+                    "drop-off-location":drop_off,
+                    "phone-number":$('.phone-number').val()
                 }
                 $.ajax({
                     type: 'POST',

--- a/shuttle/templates/request_shuttle/request_shuttle.html
+++ b/shuttle/templates/request_shuttle/request_shuttle.html
@@ -33,7 +33,13 @@
                             {% for location in locations %}
                                 <a class="dropdown-item" href="#">{{ location }}</a>
                             {% endfor %}
+                            <a class="dropdown-item" href="#">Other</a>
                         </div>
+                    </div>
+                </div>
+                <div class="align-side-by-side">
+                    <div class="pick-up-other" style="display: none">
+                        <input class="pick-up-input" type="tel" id="phone" name="phone" placeholder="Please Enter Location">
                     </div>
                 </div>
             </div>
@@ -48,10 +54,24 @@
                             {% for location in locations %}
                                 <a class="dropdown-item" href="#">{{ location }}</a>
                             {% endfor %}
+                            <a class="dropdown-item" href="#">Other</a>
                         </div>
                     </div>
                 </div>
+                <div class="align-side-by-side">
+                    <div class="drop-off-other" style="display: none">
+                        <input class="drop-off-input" type="tel" id="phone" name="phone" placeholder="Please Enter Location">
+                    </div>
+                </div>
             </div>
+            <form>
+                <div class="align-side-by-side">
+                    <h4>Phone number (Optional):</h4>
+                </div>
+                <div class="align-side-by-side">
+                    <input type="tel" id="phone" name="phone" placeholder="___-___-____" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
+                </div>
+            </form>
             <div class="center-page">
                 <div class="align-side-by-side">
                     <div class="submit">
@@ -91,23 +111,43 @@
                 // Dropdown shows location selected
                 $(".pick-up-menu:first-child").text($(this).text());
                 $(".pick-up-menu:first-child").val($(this).text());
+                if($(".pick-up-menu:first-child").text() == 'Other'){
+                    $('.pick-up-other').show()
+                }else{
+                    $('.pick-up-other').hide()
+                }
             });
             $(".dropdown-drop-off a").click(function(){
                 // Dropdown shows location selected
                 $(".drop-off-menu:first-child").text($(this).text());
                 $(".drop-off-menu:first-child").val($(this).text());
+                if($(".drop-off-menu:first-child").text() == 'Other'){
+                    $('.drop-off-other').show()
+                }else{
+                    $('.drop-off-other').hide()
+                }
             });
             $('.submit-btn').click(function () {
                 // Sends selected location and user info to database. Updates waitlist
+                if($(".pick-up-menu:first-child").text() == 'Other'){
+                    var pick_up = $('.pick-up-input').val()
+                }else{
+                    var pick_up = $('.pick-up-menu').val()
+                }
+                if($(".drop-off-menu:first-child").text() == 'Other'){
+                    var drop_off = $('.drop-off-input').val()
+                }else{
+                    var drop_off = $('.drop-off-menu').val()
+                }
                 var data = {
-                    "pick-up-location":$('.pick-up-menu').val(),
-                    "drop-off-location":$('.drop-off-menu').val()
+                    "pick-up-location":pick_up,
+                    "drop-off-location":drop_off
                 }
                 $.ajax({
                     type: 'POST',
                     contentType: 'application/json',
                     url: "{{ url_for('RequestShuttleView:send_shuttle_request_path') }}",
-                    data: JSON.stringify((data)),
+                    data: JSON.stringify(data),
                 }).done(function () {
                     location.reload();
                 })

--- a/shuttle/templates/request_shuttle/request_shuttle.html
+++ b/shuttle/templates/request_shuttle/request_shuttle.html
@@ -20,28 +20,6 @@
         <div class="center-page shuttle-margins">
             <h3>Number Of Users Waiting For On Call Shuttle: <span class="badge badge-pill badge-warning waitlist">{{ active_requests['waitlist-num'] }}</span></h3>
         </div>
-        <div class="center-page">
-            {% if phone_number %}
-                <div class="align-side-by-side">
-                    <h4>Phone number On Record: <b>{{ phone_number }}</b></h4>
-                </div>
-                <div class="align-side-by-side">
-                    <input class="btn btn-danger btn-sm delete-number" type="button" value="Delete">
-                </div>
-            {% else %}
-                <form>
-                    <div class="align-side-by-side">
-                        <h4>Phone number:</h4>
-                    </div>
-                    <div class="align-side-by-side">
-                        <input class="phone-number" type="tel" id="phone" name="phone" placeholder="ex. 123-123-1234">
-                    </div>
-                    <div class="align-side-by-side">
-                        <h6>(Optional)</h6>
-                    </div>
-                </form>
-            {% endif %}
-        </div>
         <div class="center-page shuttle-margins">
             <h4>Select pick up and drop off location below to request a shuttle</h4>
             <div class="center-page">
@@ -85,6 +63,25 @@
                         <input class="drop-off-input" placeholder="Please Enter Location">
                     </div>
                 </div>
+            </div>
+            <div class="center-page">
+                {% if phone_number %}
+                    <div class="align-side-by-side">
+                        <h4>Phone number: <b>{{ phone_number }}</b></h4>
+                    </div>
+                    <div class="align-side-by-side">
+                        <input class="btn btn-danger btn-sm delete-number" type="button" value="Delete">
+                    </div>
+                {% else %}
+                    <form>
+                        <div class="align-side-by-side">
+                            <h4>Phone number:</h4>
+                        </div>
+                        <div class="align-side-by-side">
+                            <input class="phone-number" type="tel" id="phone" name="phone" placeholder="ex. 123-123-1234">
+                        </div>
+                    </form>
+                {% endif %}
             </div>
             <div class="center-page">
                 <div class="align-side-by-side">

--- a/shuttle/templates/request_shuttle/request_shuttle.html
+++ b/shuttle/templates/request_shuttle/request_shuttle.html
@@ -12,7 +12,7 @@
                 <div class="card-body">
                     <h4>Pick Up: <span class="badge badge-pill badge-warning pick-up-status">{{ active_requests['requested-pick-up'] }}</span></h4>
                     <h4>Drop Off: <span class="badge badge-pill badge-warning drop-off-status">{{ active_requests['requested-drop-off'] }}</span></h4>
-                    <input class="btn btn-danger btn-sm delete-btn" type="submit" value="Delete Request">
+                    <input class="btn btn-danger btn-sm delete-request" type="submit" value="Delete Request">
                 </div>
             </div>
         </div>
@@ -20,8 +20,30 @@
         <div class="center-page shuttle-margins">
             <h3>Number Of Users Waiting For On Call Shuttle: <span class="badge badge-pill badge-warning waitlist">{{ active_requests['waitlist-num'] }}</span></h3>
         </div>
+        <div class="center-page">
+            {% if phone_number %}
+                <div class="align-side-by-side">
+                    <h4>Phone number On Record: <b>{{ phone_number }}</b></h4>
+                </div>
+                <div class="align-side-by-side">
+                    <input class="btn btn-danger btn-sm delete-number" type="button" value="Delete">
+                </div>
+            {% else %}
+                <form>
+                    <div class="align-side-by-side">
+                        <h4>Phone number:</h4>
+                    </div>
+                    <div class="align-side-by-side">
+                        <input class="phone-number" type="tel" id="phone" name="phone" placeholder="ex. 123-123-1234">
+                    </div>
+                    <div class="align-side-by-side">
+                        <h6>(Optional)</h6>
+                    </div>
+                </form>
+            {% endif %}
+        </div>
         <div class="center-page shuttle-margins">
-            <h4>Select pick up and drop off location below to request a shuttle:</h4>
+            <h4>Select pick up and drop off location below to request a shuttle</h4>
             <div class="center-page">
                 <div class="align-side-by-side">
                     <h4>Pick Up:</h4>
@@ -39,7 +61,7 @@
                 </div>
                 <div class="align-side-by-side">
                     <div class="pick-up-other" style="display: none">
-                        <input class="pick-up-input" type="tel" id="phone" name="phone" placeholder="Please Enter Location">
+                        <input class="pick-up-input" placeholder="Please Enter Location">
                     </div>
                 </div>
             </div>
@@ -60,27 +82,10 @@
                 </div>
                 <div class="align-side-by-side">
                     <div class="drop-off-other" style="display: none">
-                        <input class="drop-off-input" type="tel" id="phone" name="phone" placeholder="Please Enter Location">
+                        <input class="drop-off-input" placeholder="Please Enter Location">
                     </div>
                 </div>
             </div>
-            {% if phone_number %}
-                <div class="align-side-by-side">
-                    <p>Phone number On Record: <b>{{ phone_number }}</b></p>
-                </div>
-            {% else %}
-                <form>
-                    <div class="align-side-by-side">
-                        <h4>Phone number:</h4>
-                    </div>
-                    <div class="align-side-by-side">
-                        <input class="phone-number" type="tel" id="phone" name="phone" placeholder="ex. 123-123-1234" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">
-                    </div>
-                    <div class="align-side-by-side">
-                        <h6>(Optional)</h6>
-                    </div>
-                </form>
-            {% endif %}
             <div class="center-page">
                 <div class="align-side-by-side">
                     <div class="submit">
@@ -148,11 +153,17 @@
                 }else{
                     var drop_off = $('.drop-off-menu').val()
                 }
+                if($('.phone-number').val() == undefined){
+                    var phone_number = ''
+                }else{
+                    var phone_number = $('.phone-number').val()
+                }
                 var data = {
                     "pick-up-location":pick_up,
                     "drop-off-location":drop_off,
-                    "phone-number":$('.phone-number').val()
+                    "phone-number":phone_number
                 }
+                console.log(data);
                 $.ajax({
                     type: 'POST',
                     contentType: 'application/json',
@@ -162,10 +173,18 @@
                     location.reload();
                 })
             });
-            $('.delete-btn').click(function () {
+            $('.delete-request').click(function () {
                 // Deletes user's current shuttle request
                 $.ajax({
                     url: "{{ url_for('RequestShuttleView:delete_request') }}",
+                }).done(function () {
+                    location.reload();
+                })
+            });
+            $('.delete-number').click(function () {
+                // Deletes user's current phone number
+                $.ajax({
+                    url: "{{ url_for('RequestShuttleView:delete_number') }}",
                 }).done(function () {
                     location.reload();
                 })


### PR DESCRIPTION
## Description

You can now add in a phone number when requesting a shuttle so the driver can call if needed. You can also now type a manual location.

Fixes #N/A

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

I requested a shuttle with and without a phone number and that information was shown in the driver's active requests and in the db. I also deleted my number and that worked correctly. I chose "other" and typed in manual locations and those worked correctly. I couldn't have a blank location or type the same name as the other location selected.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
